### PR TITLE
Directly splice `table` array instead of looping & manually tracking lineNumber

### DIFF
--- a/lit-datatable.js
+++ b/lit-datatable.js
@@ -192,12 +192,11 @@ class LitDatatable extends LitElement {
   }
 
   cleanTrElements() {
-    [...this.table].forEach((line, lineNumber) => {
-      if (lineNumber >= (this.data.length)) {
-        this.cleanEventsOfTr(line);
-        this.shadowRoot.querySelector('tbody').removeChild(line.element);
-        this.table.splice(lineNumber, 1);
-      }
+    const splices = this.table.splice(this.data.length);
+
+    splices.forEach(line => {
+      this.cleanEventsOfTr(line);
+      line.element.parentNode.removeChild(line.element);
     });
   }
 


### PR DESCRIPTION
I believe issue #3 is related to the `lineNumber` variable not referencing the correct index in the `this.table` array when splicing. This PR updates the `cleanTrElements` method to directly splice the `this.table` array based on the new length of the `this.data` array