### PR TITLE
remove/add tap event listener on each tr tag when updateBody is called

### DIFF
--- a/lit-datatable.js
+++ b/lit-datatable.js
@@ -1,6 +1,8 @@
 import {
-  LitElement, html, css, render,
+  LitElement, html, css
 } from 'lit-element';
+
+import { render } from 'lit-html';
 
 class LitDatatable extends LitElement {
   static get styles() {
@@ -206,7 +208,7 @@ class LitDatatable extends LitElement {
     tr.addEventListener('tap', trTapEvent);
     tr.addEventListener('mouseover', trOverEvent);
     tr.addEventListener('mouseout', trOutEvent);
-    return [{ type: 'mouseover', event: trOverEvent }, { type: 'mouseout', event: trOutEvent }];
+    return [{ type: 'mouseover', event: trOverEvent }, { type: 'mouseout', event: trOutEvent }, { type: 'tap', event: trTapEvent }];
   }
 
   cleanTrElements() {


### PR DESCRIPTION
When updateBody is called, tap event of tr element was not reset (remove and add listeners were called only for mouseover/mouseout events)