### PR TITLE
fix: when stickyHeader changes, update header style

### DIFF
--- a/lit-datatable.ts
+++ b/lit-datatable.ts
@@ -147,7 +147,7 @@ export class LitDatatable extends LitElement {
     `;
   }
 
-  updated(properties: PropertyValues<{data: Array<unknown>; conf: Array<Conf>; sort: string}>) {
+  updated(properties: PropertyValues<{ data: Array<unknown>; conf: Array<Conf>; sort: string, stickyHeader: boolean }>) {
     // Data or conf change we have to generate the table
     if ((properties.has('data') && !deepEqual(properties.get('data'), this.data))
       || (properties.has('conf') && !deepEqual(properties.get('conf'), this.conf))) {
@@ -155,7 +155,7 @@ export class LitDatatable extends LitElement {
       this.generateData();
     }
 
-    if (properties.has('conf')) {
+    if (properties.has('conf') || properties.has('stickyHeader')) {
       const confs = [...this.conf].filter((c) => !c.hidden);
       this.updateHeaders(confs);
     }
@@ -302,11 +302,9 @@ export class LitDatatable extends LitElement {
           th = this.headers[i];
         } else {
           th = document.createElement('th');
-          if (this.stickyHeader) {
-            th.classList.add('sticky');
-          }
           this.headers.push(th);
         }
+        th.classList.toggle('sticky', this.stickyHeader);
         if (datatableHeader && datatableHeader.columnStyle) {
           th.setAttribute('style', datatableHeader.columnStyle);
         } else {

--- a/test/unit/lit-datatable.test.ts
+++ b/test/unit/lit-datatable.test.ts
@@ -315,4 +315,16 @@ describe('lit-datatable', () => {
       expect(eachThIsSticky).to.be.equal(true);
     }
   });
+
+  it('non sticky header', async () => {
+    const litDatatable = new LitDatatableTest();
+    await litDatatable.init(basicConf, basicData, false);
+    await litDatatable.elementUpdated();
+    const { headThs } = litDatatable;
+    expect(headThs).to.be.not.equal(null);
+    if (headThs) {
+      const eachThIsSticky = Array.from(headThs).every((th) => th.classList.contains('sticky'));
+      expect(eachThIsSticky).to.be.equal(false);
+    }
+  });
 });


### PR DESCRIPTION
When updating sticky header attribute, it should update headers.
Today it was triggering the updateHeaders but taking the `th` from cache without reomving the sticky class